### PR TITLE
Enable call recording for Bardock and BardockPro

### DIFF
--- a/overlay/packages/apps/dialer/callrecord/res/values/config.xml
+++ b/overlay/packages/apps/dialer/callrecord/res/values/config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <bool name="call_recording_enabled">true</bool>
+    <integer name="call_recording_audio_source">1</integer>
+</resources>


### PR DESCRIPTION
Enable call recording for Bardock and BardockPro.

According to https://review.lineageos.org/c/LineageOS/android_packages_apps_Dialer/+/219890/, it has to be enabled per device and per MCC country code of the SIM card. This pull request is for the per-device enablement.

Please check if "call_recording_audio_source" is set to the correct value for BARDOCK and BARDOCKPRO.

I can test it as soon as this pull request and the pull request "Enable call recording for Austria" (https://github.com/LineageOS/android_packages_apps_Dialer/pull/5) is included in a nightly build.